### PR TITLE
ci: add codex-plugin-scanner workflow

### DIFF
--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -1,0 +1,39 @@
+name: Codex Plugin Scanner CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.codex-plugin/**'
+      - 'skills/**'
+      - '.mcp.json'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.codex-plugin/**'
+      - 'skills/**'
+      - '.mcp.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: scanner-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: Plugin Scanner
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
+
+      - name: Run scanner
+        continue-on-error: true
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@b159c3199f338f4767b225fa748484401ad40563
+        with:
+          plugin_dir: "."
+          mode: scan
+          fail_on_severity: critical


### PR DESCRIPTION
This adds one validate-only workflow for the plugin metadata already in this repo.

The change is limited to one workflow file. Permissions stay read-only, and runtime code is untouched.

It only checks the metadata files already in the repo.
No secrets or publish step are involved.

No runtime code or release flow changes are included here, and the workflow can be removed cleanly if it does not fit your setup.
If you would rather fold it into existing CI or place it under a different filename, I can adjust the branch.